### PR TITLE
Fix: Read the workspaceId from the config file

### DIFF
--- a/ProvisionSample/Program.cs
+++ b/ProvisionSample/Program.cs
@@ -33,9 +33,9 @@ namespace ProvisionSample
         static string clientId = ConfigurationManager.AppSettings["clientId"];
         static string accessKey = ConfigurationManager.AppSettings["accessKey"];
         static string datasetId = ConfigurationManager.AppSettings["datasetId"];
+        static string workspaceId = ConfigurationManager.AppSettings["workspaceId"];
 
         static WorkspaceCollectionKeys accessKeys = null;
-        private static string workspaceId = null;
 
         static void Main(string[] args)
         {


### PR DESCRIPTION
For example, step 6 checks to see if 'workspaceId' is available, but its never read from the app.config file. So it was always null. 

This simple fix now reads the workspaceId from the app.config, assuming it has no need to be different than the other variables.
